### PR TITLE
fix: NPC type rendering

### DIFF
--- a/styles/motw-for-pbta.css
+++ b/styles/motw-for-pbta.css
@@ -210,6 +210,11 @@ span.attr-icon.attr-rollable.rollable:hover .fa-dice-d6 {
   cursor: pointer;
 }
 
+.pbta.sheet :is(.cell--attr-type) .cell__checkboxes {
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
 .pbta.sheet .cell__title button, .pbta.sheet .cell__subtitle button {
   color: #8e2231;
   border: 1px solid #8e2231;


### PR DESCRIPTION
Because of a CSS rule inside the system, the rendering of NPC type is bad and we can not click on tabs.
This modification fix the rendering by overriding the system rule.

* Left: current rendering
* Right: fixed rendering

![image](https://github.com/Rangertheman/motw-for-pbta/assets/696780/2855ae71-8f93-4618-a9f2-db89a5f1f015)


P.S.: I guess it will be maybe better to handle this problem in the system itself?