### PR TITLE
fix: remove ligature on a translation

### DIFF
--- a/languages/fr.json
+++ b/languages/fr.json
@@ -124,7 +124,7 @@
   },
   "PBTA": {
     "Description": "Description",
-    "Moves": "Manœuvres",
+    "Moves": "Manoeuvres",
     "Equipment": "Équipement",
     "Biography": "Biographie",
     "Playbook": "Livret"


### PR DESCRIPTION
- The font used on tabs doesn’t support the "œ" ligature

Sorry, I haven’t seen it yesterday... :( 